### PR TITLE
Adding vite/client to tsconfig.json

### DIFF
--- a/src/renderer/tsconfig.json
+++ b/src/renderer/tsconfig.json
@@ -9,7 +9,8 @@
       "sourceMap": true,
       "resolveJsonModule": true,
       "esModuleInterop": true,
-      "lib": ["esnext", "dom"]
+      "lib": ["esnext", "dom"],
+      "types": ["vite/client"]
     },
     "include": ["./**/*.ts", "./**/*.d.ts", "./**/*.tsx", "./**/*.vue"],
   }


### PR DESCRIPTION
Adding vite/client to tsconfig.json compiler options, as recommended on Vite docs: https://vitejs.dev/guide/features.html#client-types. It avoids the following errors when using tsc:

```
Property 'env' does not exist on type 'ImportMeta'
````

![image](https://user-images.githubusercontent.com/11933789/191982637-86d4a9ec-5d96-480a-be92-b0e306e0fa86.png)
