### PR TITLE
Changed renderer -> main communication example 

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import {contextBridge, ipcRenderer} from 'electron';
 
-contextBridge.exposeInMainWorld('electron', {
-  ipcRenderer: ipcRenderer,
+contextBridge.exposeInMainWorld('electronAPI', {
+  sendMessage: (channel:string, message:string) => ipcRenderer.send(channel, message)
 })

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import Hello from './components/Hello.vue'
 
-window.electron.ipcRenderer.send('message', 'Hello from App.vue!');
+window.electronAPI.sendMessage('message', 'Hello from App.vue!');
 </script>
 
 <template>

--- a/src/renderer/typings/electron.d.ts
+++ b/src/renderer/typings/electron.d.ts
@@ -1,14 +1,12 @@
-import * as Electron from 'electron';
-
 /**
  * Should match main/preload.ts for typescript support in renderer
  */
 export default interface ElectronApi {
-  ipcRenderer: Electron.IpcRenderer,
+  sendMessage: (channel:string ,message: string) => void
 }
 
 declare global {
   interface Window {
-    electron: ElectronApi,
+    electronAPI: ElectronApi,
   }
 }


### PR DESCRIPTION
Changed the basic included example to satisfy security recommedations by Electron Team in:

1. https://www.electronjs.org/docs/latest/tutorial/context-isolation
2. https://www.electronjs.org/docs/latest/tutorial/ipc

Mainly not exposing ipcRenderer.send as it is a security risk.