### PR TITLE
Update directory structure of packaged app

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -16,7 +16,11 @@
         "target": ["snap"]
     },
     "files": [
-        "build/main/**/*",
+        {
+            "from": "build/main",
+            "to": "main",
+            "filter": ["**/*"]
+        },
         {
             "from": "build/renderer",
             "to": "renderer",
@@ -27,15 +31,18 @@
             "to": "static",
             "filter": ["**/*"]
         },
-        "!**/node_modules/*/{CHANGELOG.md,README.md,README,readme.md,readme}",
-        "!**/node_modules/*/{test,__tests__,tests,powered-test,example,examples}",
-        "!**/node_modules/*.d.ts",
-        "!**/node_modules/.bin",
-        "!src",
-        "!config",
-        "!README.md",
-        "!scripts",
-        "!build/renderer",
-        "!dist"
+        {
+            "from": "node_modules",
+            "to": "node_modules",
+            "filter": [
+                "**/*",
+                "!**/{CHANGELOG.md,README.md,README,readme.md,readme}",
+                "!**/{test,__tests__,tests,powered-test,example,examples}",
+                "!**/*.d.ts",
+                "!**/.bin"
+            ]
+        },
+        "!**/*",
+        "package.json"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "electron-vue-template",
   "version": "0.1.0",
   "description": "A minimal Electron + Vue application",
-  "main": "build/main/main.js",
+  "main": "main/main.js",
   "scripts": {
     "dev": "node scripts/dev-server.js",
     "build": "node scripts/build.js && electron-builder",


### PR DESCRIPTION
After some testing I realized that the structure of the packaged app was very inconsistent. I noticed that the files of the main process ended up in `<asar>/build/main/`. This path heavily deviates from where the files of the renderer process are: `<asar>/renderer`.

This PR simply changes the project structure so that both main and renderer processes are on the same path level: `<asar>/renderer` and `<asar>/main`.

Old structure:

```txt
> build/
  > main/
> node_modules/
> renderer/
> static/
> package.json
```

New structure:

```txt
> main/
> node_modules/
> renderer/
> static/
> package.json
```

This _shouldn't_ affect any developers using this template, as only the entry point of the Electron app is important for Electron Builder to know, which has been updated in `package.json`.

A smaller change, that however, can be noted as a backwards incompatible change is that the `electron-builder.json` config is now more selective over which files get copied over to the packaged build. Previously, files and folders in the root of the project were all considered to be part of the final build. This could unexpectedly create huge builds as all of these unnecessary files were copied over. Think of files/folders related to CI/CD, or even other projects.